### PR TITLE
Allow .vscode but ignore .vscode/launch.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,10 @@ _ide_helper_models.php
 # Editors
 /.idea
 /.fleet
-/.vscode
+
+# We allow vscode config as formatter setup exists there
+#/.vscode
+/.vscode/launch.json
 
 # Misc
 phpunit.xml

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,16 @@
+{
+  "recommendations": [
+    "open-southeners.laravel-pint",
+    "esbenp.prettier-vscode",
+    "shufo.vscode-blade-formatter",
+    "laravel.vscode-laravel",
+    "alefragnani.project-manager",
+    "bradgashler.htmltagwrap",
+    "redhat.vscode-yaml",
+    "bradlc.vscode-tailwindcss",
+    "formulahendry.auto-close-tag",
+    "patbenatar.advanced-new-file",
+    "marcoroth.stimulus-lsp",
+    "marcoroth.turbo-lsp"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[php]": {
+    "editor.defaultFormatter": "open-southeners.laravel-pint",
+    "editor.formatOnSave": true
+  },
+  "[blade]": {
+    "editor.defaultFormatter": "shufo.vscode-blade-formatter"
+  },
+  "[css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "prettier.configPath": "./.prettierrc",
+  "prettier.requireConfig": true,
+  "laravel-pint.enable": true
+}


### PR DESCRIPTION
This release only removes `.vscode` from `.gitignore` because the formatting setup needed for a front-end package is hard, this way developers can easily contribute in terms of setting up proper formatting on their machine. 

#### Breaking Changes
- No breaking changes

#### New Features
- No new features

#### Bug Fixes
- No bug fixes 
