### PR TITLE
Use globe matching for npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,7 +3,7 @@ name: Publish to NPM Registry
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+*'
+      - '[0-9]*.[0-9]*.[0-9]*'
 
 jobs:
   release:


### PR DESCRIPTION
#### Breaking Changes

- No breaking changes

#### New Features

- No new features

#### Bug Fixes

- Fixes the issue with `npm-publish.yml` workflow not getting triggered on new tags, seems github uses glob matching and we were using regex.
